### PR TITLE
Start unmanaged backup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,6 @@ packages:
 
 build: backupshq
 
+.PHONY: backupshq
 backupshq:
 	go build -o backupshq

--- a/actions/backup.go
+++ b/actions/backup.go
@@ -1,0 +1,47 @@
+package actions
+
+
+import "encoding/json"
+import "fmt"
+import "io/ioutil"
+import "log"
+import "net/http"
+import "../auth"
+
+const BACKUP_TYPE_UNMANAGED = 0
+const BACKUP_TYPE_UNSCHEDULED = 1
+const BACKUP_TYPE_SCHEDULED = 2
+
+type Backup struct {
+	ID string
+	Name string
+	Description string
+	Type int
+}
+
+func GetBackup(client *http.Client, tokenResponse auth.AccessTokenResponse, backupId string) Backup {
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:8000/backups/%s", backupId), nil)
+	if err != nil {
+		log.Fatal("Error reading request. ", err)
+	}
+	auth.AddAuthHeader(req, tokenResponse)
+	
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal("Error reading response. ", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		log.Fatal("Unable to start job: HTTP " + resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal("Error reading body. ", err)
+	}
+
+	var backup Backup
+	err = json.Unmarshal(body, &backup)
+	return backup
+}

--- a/actions/job.go
+++ b/actions/job.go
@@ -1,26 +1,28 @@
 package actions
 
-import (
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"log"
-	"net/http"
 
-	"../auth"
-)
+import "encoding/json"
+import "fmt"
+import "io/ioutil"
+import "log"
+import "net/http"
+import "net/url"
+import "strings"
+import "../auth"
+
 
 type Job struct {
 	ID string
 }
 
-func StartJob(client *http.Client, tokenResponse auth.AccessTokenResponse, backupId string) Job {
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/backups/%s/start", backupId), nil)
+func StartJob(client *http.Client, tokenResponse auth.AccessTokenResponse, backupId string, context url.Values) Job {
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/backups/%s/start", backupId), strings.NewReader(context.Encode()))
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}
 	auth.AddAuthHeader(req, tokenResponse)
-
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Fatal("Error reading response. ", err)

--- a/actions/job.go
+++ b/actions/job.go
@@ -1,0 +1,59 @@
+package actions
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"../auth"
+)
+
+type Job struct {
+	ID string
+}
+
+func StartJob(client *http.Client, tokenResponse auth.AccessTokenResponse, backupId string) Job {
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/backups/%s/start", backupId), nil)
+	if err != nil {
+		log.Fatal("Error reading request. ", err)
+	}
+	auth.AddAuthHeader(req, tokenResponse)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal("Error reading response. ", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		log.Fatal("Unable to start job: HTTP " + resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal("Error reading body. ", err)
+	}
+
+	var startedJob Job
+	err = json.Unmarshal(body, &startedJob)
+
+	return startedJob
+}
+
+func FinishJob(client *http.Client, tokenResponse auth.AccessTokenResponse, job Job) {
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/jobs/%s/finish", job.ID), nil)
+	if err != nil {
+		log.Fatal("Error reading request. ", err)
+	}
+	auth.AddAuthHeader(req, tokenResponse)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal("Error reading response. ", err)
+	}
+	defer resp.Body.Close()
+
+	return
+}

--- a/actions/job.go
+++ b/actions/job.go
@@ -6,8 +6,6 @@ import "fmt"
 import "io/ioutil"
 import "log"
 import "net/http"
-import "net/url"
-import "strings"
 import "../auth"
 
 
@@ -15,13 +13,12 @@ type Job struct {
 	ID string
 }
 
-func StartJob(client *http.Client, tokenResponse auth.AccessTokenResponse, backupId string, context url.Values) Job {
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/backups/%s/start", backupId), strings.NewReader(context.Encode()))
+func StartJob(client *http.Client, tokenResponse auth.AccessTokenResponse, backupId string) Job {
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/backups/%s/start", backupId), nil)
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}
 	auth.AddAuthHeader(req, tokenResponse)
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	
 	resp, err := client.Do(req)
 	if err != nil {
@@ -40,7 +37,6 @@ func StartJob(client *http.Client, tokenResponse auth.AccessTokenResponse, backu
 
 	var startedJob Job
 	err = json.Unmarshal(body, &startedJob)
-
 	return startedJob
 }
 

--- a/command/backup_run.go
+++ b/command/backup_run.go
@@ -3,12 +3,11 @@ package command
 import "fmt"
 import "github.com/urfave/cli"
 import "time"
-import "io/ioutil"
 import "log"
 import "net/http"
-import "encoding/json"
 import "../config"
 import "../auth"
+import "../actions"
 
 var BackupRun = cli.Command{
 	Name:  "run",
@@ -24,63 +23,15 @@ var BackupRun = cli.Command{
 		client := &http.Client{
 			Timeout: time.Second * 3,
 		}
-		job := startJob(client, tokenResponse, c.Args().Get(0))
+		job := actions.StartJob(client, tokenResponse, c.Args().Get(0))
 		fmt.Printf("Started a new job with id %q.\n", job.ID)
 
 		fmt.Println("Running backup...")
 		time.Sleep(3 * time.Second)
 
 		fmt.Println("Publishing results to API.")
-		finishJob(client, tokenResponse, job)
+		actions.FinishJob(client, tokenResponse, job)
 
 		return nil
 	},
-}
-
-type job struct {
-	ID string
-}
-
-func startJob(client *http.Client, tokenResponse auth.AccessTokenResponse, backupId string) job {
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/backups/%s/start", backupId), nil)
-	if err != nil {
-		log.Fatal("Error reading request. ", err)
-	}
-	auth.AddAuthHeader(req, tokenResponse)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Fatal("Error reading response. ", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		log.Fatal("Unable to start job: HTTP " + resp.Status)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		log.Fatal("Error reading body. ", err)
-	}
-
-	var startedJob job
-	err = json.Unmarshal(body, &startedJob)
-
-	return startedJob
-}
-
-func finishJob(client *http.Client, tokenResponse auth.AccessTokenResponse, job job) {
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/jobs/%s/finish", job.ID), nil)
-	if err != nil {
-		log.Fatal("Error reading request. ", err)
-	}
-	auth.AddAuthHeader(req, tokenResponse)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Fatal("Error reading response. ", err)
-	}
-	defer resp.Body.Close()
-
-	return
 }

--- a/command/backup_run.go
+++ b/command/backup_run.go
@@ -23,7 +23,7 @@ var BackupRun = cli.Command{
 		client := &http.Client{
 			Timeout: time.Second * 3,
 		}
-		job := actions.StartJob(client, tokenResponse, c.Args().Get(0))
+		job := actions.StartJob(client, tokenResponse, c.Args().Get(0), nil)
 		fmt.Printf("Started a new job with id %q.\n", job.ID)
 
 		fmt.Println("Running backup...")

--- a/command/backup_run.go
+++ b/command/backup_run.go
@@ -23,7 +23,7 @@ var BackupRun = cli.Command{
 		client := &http.Client{
 			Timeout: time.Second * 3,
 		}
-		job := actions.StartJob(client, tokenResponse, c.Args().Get(0), nil)
+		job := actions.StartJob(client, tokenResponse, c.Args().Get(0))
 		fmt.Printf("Started a new job with id %q.\n", job.ID)
 
 		fmt.Println("Running backup...")

--- a/command/backup_start_unmanaged.go
+++ b/command/backup_start_unmanaged.go
@@ -16,10 +16,16 @@ var BackupStartUnmanaged = cli.Command{
 Start an unmanaged backup.
 This command is only suitable for *unmanaged* backups that you handle yourself, for example:
 
-backupshq start-unmanaged <backup_id> > job-id.txt && ./backup-script.sh | backupshq finish-unmanaged $(cat job-id.txt) --log-stdin
+backupshq start-unmanaged --id <backup_id> > job-id.txt && ./backup-script.sh | backupshq finish-unmanaged $(cat job-id.txt) --log-stdin
 
 To run any other type of backup, see backupshq job run --help.
 `,
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:   "id",
+			Usage:  "Output only the new job ID",
+		},
+	},
 	Action: func(c *cli.Context) error {
 		config := config.LoadCli(c)
 
@@ -39,9 +45,13 @@ To run any other type of backup, see backupshq job run --help.
 		}
 
 		job := actions.StartJob(client, tokenResponse, backupID)
+		if c.Bool("id") {
+			fmt.Printf("%s\n", job.ID)
+			return nil
+		}
 		fmt.Printf("Started a new job with id %q.\n", job.ID)
 		fmt.Printf("To inform the API when this job is finished run: backupshq finish-unmanaged %q\n", job.ID)
-
+		
 		return nil
 	},
 }

--- a/command/backup_start_unmanaged.go
+++ b/command/backup_start_unmanaged.go
@@ -5,7 +5,6 @@ import "github.com/urfave/cli"
 import "time"
 import "log"
 import "net/http"
-import "net/url"
 import "../config"
 import "../auth"
 import "../actions"
@@ -32,9 +31,14 @@ To run any other type of backup, see backupshq job run --help.
 		client := &http.Client{
 			Timeout: time.Second * 3,
 		}
-		context := url.Values{}
-		context.Set("unmanaged", "true")
-		job := actions.StartJob(client, tokenResponse, c.Args().Get(0), context)
+
+		backupID := c.Args().Get(0)
+		backup := actions.GetBackup(client, tokenResponse, backupID)
+		if (backup.Type != actions.BACKUP_TYPE_UNMANAGED) {
+			log.Fatal("Cannot start managed backup using start-unmanaged command")
+		}
+
+		job := actions.StartJob(client, tokenResponse, backupID)
 		fmt.Printf("Started a new job with id %q.\n", job.ID)
 		fmt.Printf("To inform the API when this job is finished run: backupshq finish-unmanaged %q\n", job.ID)
 

--- a/command/backup_start_unmanaged.go
+++ b/command/backup_start_unmanaged.go
@@ -1,6 +1,13 @@
 package command
 
+import "fmt"
 import "github.com/urfave/cli"
+import "time"
+import "log"
+import "net/http"
+import "../config"
+import "../auth"
+import "../actions"
 
 var BackupStartUnmanaged = cli.Command{
 	Name:  "start-unmanaged",
@@ -14,6 +21,20 @@ backupshq start-unmanaged <backup_id> > job-id.txt && ./backup-script.sh | backu
 To run any other type of backup, see backupshq job run --help.
 `,
 	Action: func(c *cli.Context) error {
+		config := config.LoadCli(c)
+
+		tokenResponse, err := auth.GetAccessToken(config)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		client := &http.Client{
+			Timeout: time.Second * 3,
+		}
+		job := actions.StartJob(client, tokenResponse, c.Args().Get(0))
+		fmt.Printf("Started a new job with id %q.\n", job.ID)
+		fmt.Printf("To inform the API when this job is finished run: backupshq finish-unmanaged %q\n", job.ID)
+
 		return nil
 	},
 }

--- a/command/backup_start_unmanaged.go
+++ b/command/backup_start_unmanaged.go
@@ -5,6 +5,7 @@ import "github.com/urfave/cli"
 import "time"
 import "log"
 import "net/http"
+import "net/url"
 import "../config"
 import "../auth"
 import "../actions"
@@ -31,7 +32,9 @@ To run any other type of backup, see backupshq job run --help.
 		client := &http.Client{
 			Timeout: time.Second * 3,
 		}
-		job := actions.StartJob(client, tokenResponse, c.Args().Get(0))
+		context := url.Values{}
+		context.Set("unmanaged", "true")
+		job := actions.StartJob(client, tokenResponse, c.Args().Get(0), context)
 		fmt.Printf("Started a new job with id %q.\n", job.ID)
 		fmt.Printf("To inform the API when this job is finished run: backupshq finish-unmanaged %q\n", job.ID)
 


### PR DESCRIPTION
This branch implements the `start-unmanaged` command. It will make an API request which creates a job for the target backup if it has the type unmanaged, otherwise the API will return an error.

To communicate to the API that the job is going to be unmanaged, when making a request to the `/start` endpoint an `unmanaged: true` parameter is sent in the POST request. 

The Start/Finish job methods are also extracted into the `actions/job.go` file since the logic for them can be reused here. Do you think `actions` a suitable name for the folder or should it be something else?

I also added `.PHONY: backupshq` to the Makefile since I was having to manually delete the binary every time I wanted to run `make build`. Is that the best way to prevent that?