### PR TITLE
Finish unmanaged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /backupshq
 /config.toml
+/job-id.txt
+/backup-script.sh

--- a/command/backup_finish_unmanaged.go
+++ b/command/backup_finish_unmanaged.go
@@ -1,11 +1,51 @@
 package command
 
 import "github.com/urfave/cli"
+import "time"
+import "os"
+import "bufio"
+import "log"
+import "net/http"
+import "../config"
+import "../auth"
+import "../actions"
 
 var BackupFinishUnmanaged = cli.Command{
 	Name:  "finish-unmanaged",
 	Usage: "Finish an unmanaged backup",
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:   "log-stdin",
+			Usage:  "Log the stdin channel",
+		},
+	},
 	Action: func(c *cli.Context) error {
+		scanner := bufio.NewScanner(os.Stdin)
+		stdin := ""
+
+		if c.Bool("log-stdin") {
+			for scanner.Scan() {
+				text := scanner.Text()
+				log.Println(text)
+				stdin += text
+			}
+		}
+
+		config := config.LoadCli(c)
+
+		tokenResponse, err := auth.GetAccessToken(config)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		client := &http.Client{
+			Timeout: time.Second * 3,
+		}
+
+		job := actions.Job{ID: c.Args().Get(0)}
+		actions.FinishJob(client, tokenResponse, job)
+		log.Printf("Finished Job: %q.\n", job.ID)
+
 		return nil
 	},
 }

--- a/command/backup_start_unmanaged.go
+++ b/command/backup_start_unmanaged.go
@@ -16,7 +16,7 @@ var BackupStartUnmanaged = cli.Command{
 Start an unmanaged backup.
 This command is only suitable for *unmanaged* backups that you handle yourself, for example:
 
-backupshq start-unmanaged --id <backup_id> > job-id.txt && ./backup-script.sh | backupshq finish-unmanaged $(cat job-id.txt) --log-stdin
+backupshq backup start-unmanaged --id <backup_id> > job-id.txt && ./backup-script.sh | backupshq backup finish-unmanaged $(cat job-id.txt) --log-stdin
 
 To run any other type of backup, see backupshq job run --help.
 `,
@@ -49,9 +49,9 @@ To run any other type of backup, see backupshq job run --help.
 			fmt.Printf("%s\n", job.ID)
 			return nil
 		}
-		fmt.Printf("Started a new job with id %q.\n", job.ID)
-		fmt.Printf("To inform the API when this job is finished run: backupshq finish-unmanaged %q\n", job.ID)
-		
+		log.Printf("Started a new job with id %q.\n", job.ID)
+		log.Printf("To inform the API when this job is finished run: backupshq finish-unmanaged %q\n", job.ID)
+
 		return nil
 	},
 }

--- a/command/backup_start_unmanaged.go
+++ b/command/backup_start_unmanaged.go
@@ -22,8 +22,8 @@ To run any other type of backup, see backupshq job run --help.
 `,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
-			Name:   "id",
-			Usage:  "Output only the new job ID",
+			Name:  "id",
+			Usage: "Output only the new job ID",
 		},
 	},
 	Action: func(c *cli.Context) error {
@@ -40,7 +40,7 @@ To run any other type of backup, see backupshq job run --help.
 
 		backupID := c.Args().Get(0)
 		backup := actions.GetBackup(client, tokenResponse, backupID)
-		if (backup.Type != actions.BACKUP_TYPE_UNMANAGED) {
+		if backup.Type != actions.BACKUP_TYPE_UNMANAGED {
 			log.Fatal("Cannot start managed backup using start-unmanaged command")
 		}
 
@@ -50,7 +50,7 @@ To run any other type of backup, see backupshq job run --help.
 			return nil
 		}
 		log.Printf("Started a new job with id %q.\n", job.ID)
-		log.Printf("To inform the API when this job is finished run: backupshq finish-unmanaged %q\n", job.ID)
+		log.Printf("To inform the API when this job is finished run: backupshq backup finish-unmanaged %q\n", job.ID)
 
 		return nil
 	},


### PR DESCRIPTION
Implement `finish-unmanaged` command. Allows the use of a command like the following for unmanaged backups:

`backupshq backup start-unmanaged --id <backup_id> > job-id.txt && ./backup-script.sh | backupshq backup finish-unmanaged $(cat job-id.txt) --log-stdin`

