### PR TITLE
Execute backup Command with run

### DIFF
--- a/actions/backup.go
+++ b/actions/backup.go
@@ -1,22 +1,25 @@
 package actions
 
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
 
-import "encoding/json"
-import "fmt"
-import "io/ioutil"
-import "log"
-import "net/http"
-import "../auth"
+	"../auth"
+)
 
 const BACKUP_TYPE_UNMANAGED = 0
 const BACKUP_TYPE_UNSCHEDULED = 1
 const BACKUP_TYPE_SCHEDULED = 2
 
 type Backup struct {
-	ID string
-	Name string
+	ID          string
+	Name        string
 	Description string
-	Type int
+	Type        int
+	Command     string
 }
 
 func GetBackup(client *http.Client, tokenResponse auth.AccessTokenResponse, backupId string) Backup {
@@ -25,7 +28,7 @@ func GetBackup(client *http.Client, tokenResponse auth.AccessTokenResponse, back
 		log.Fatal("Error reading request. ", err)
 	}
 	auth.AddAuthHeader(req, tokenResponse)
-	
+
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Fatal("Error reading response. ", err)

--- a/command/backup_run.go
+++ b/command/backup_run.go
@@ -38,7 +38,10 @@ var BackupRun = cli.Command{
 
 		fmt.Println("Running backup...")
 		fmt.Printf("Command: %s\n\n", backup.Command)
-		out := utils.ExecuteCommand(backup.Command)
+		out, err := utils.ExecuteCommand(backup.Command)
+		if err != nil {
+			log.Fatal(err)
+		}
 		fmt.Println(out)
 
 		fmt.Println("Publishing results to API.")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,10 +2,10 @@ package utils
 
 import "os/exec"
 
-func ExecuteCommand(cmd string) string {
+func ExecuteCommand(cmd string) (string, error) {
 	out, err := exec.Command("sh", "-c", cmd).Output()
 	if err != nil {
-		return "Error executing command"
+		return "", errors.New("Error executing command: " + err.Error())
 	}
-	return string(out)
+	return string(out), nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,11 @@
+package utils
+
+import "os/exec"
+
+func ExecuteCommand(cmd string) string {
+	out, err := exec.Command("sh", "-c", cmd).Output()
+	if err != nil {
+		return "Error executing command"
+	}
+	return string(out)
+}


### PR DESCRIPTION
[API PR](https://bitbucket.org/backbeat-tech/backupshq-api/pull-requests/11/backup-commands/diff)
[App PR](https://bitbucket.org/backbeat-tech/backupshq-web/pull-requests/16/update-backup-manual-form-to-include-type/diff)

The `run` command on the agent will now execute what is in the `command` field of the Backup passed in. `ExecuteCommand()` seemed like a good candidate for moving to a utils file so I've put it in there.

My Go plugin has also reformatted all of the imports for the files I've edited. Is it ok to keep them like this or do you want me to disable the extension's auto-format option?