### PR TITLE
Send backup logs to API

### DIFF
--- a/actions/job.go
+++ b/actions/job.go
@@ -1,15 +1,14 @@
 package actions
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 
 	"../auth"
-	"../utils"
 )
 
 type Job struct {
@@ -60,11 +59,11 @@ func FinishJob(client *http.Client, tokenResponse auth.AccessTokenResponse, job 
 }
 
 func SendLogs(client *http.Client, tokenResponse auth.AccessTokenResponse, job Job, logStr string) {
-	logJSON := []byte(`{"log":"` + utils.Base64Encode(logStr) + `"}`)
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/jobs/%s/write-logs", job.ID), bytes.NewBuffer(logJSON))
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/jobs/%s/logs", job.ID), strings.NewReader(logStr))
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}
+	req.Header.Set("Content-Type", "text/plain")
 
 	auth.AddAuthHeader(req, tokenResponse)
 

--- a/actions/job.go
+++ b/actions/job.go
@@ -1,13 +1,15 @@
 package actions
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
 
-import "encoding/json"
-import "fmt"
-import "io/ioutil"
-import "log"
-import "net/http"
-import "../auth"
-
+	"../auth"
+)
 
 type Job struct {
 	ID string
@@ -19,7 +21,7 @@ func StartJob(client *http.Client, tokenResponse auth.AccessTokenResponse, backu
 		log.Fatal("Error reading request. ", err)
 	}
 	auth.AddAuthHeader(req, tokenResponse)
-	
+
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Fatal("Error reading response. ", err)
@@ -45,6 +47,24 @@ func FinishJob(client *http.Client, tokenResponse auth.AccessTokenResponse, job 
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}
+	auth.AddAuthHeader(req, tokenResponse)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal("Error reading response. ", err)
+	}
+	defer resp.Body.Close()
+
+	return
+}
+
+func SendLogs(client *http.Client, tokenResponse auth.AccessTokenResponse, job Job, logStr string) {
+	logJSON := []byte(`{"log":"` + logStr + `"}`)
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/jobs/%s/write-logs", job.ID), bytes.NewBuffer(logJSON))
+	if err != nil {
+		log.Fatal("Error reading request. ", err)
+	}
+
 	auth.AddAuthHeader(req, tokenResponse)
 
 	resp, err := client.Do(req)

--- a/actions/job.go
+++ b/actions/job.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"../auth"
+	"../utils"
 )
 
 type Job struct {
@@ -59,7 +60,7 @@ func FinishJob(client *http.Client, tokenResponse auth.AccessTokenResponse, job 
 }
 
 func SendLogs(client *http.Client, tokenResponse auth.AccessTokenResponse, job Job, logStr string) {
-	logJSON := []byte(`{"log":"` + logStr + `"}`)
+	logJSON := []byte(`{"log":"` + utils.Base64Encode(logStr) + `"}`)
 	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/jobs/%s/write-logs", job.ID), bytes.NewBuffer(logJSON))
 	if err != nil {
 		log.Fatal("Error reading request. ", err)

--- a/command/backup_run.go
+++ b/command/backup_run.go
@@ -46,6 +46,7 @@ var BackupRun = cli.Command{
 
 		fmt.Println("Publishing results to API.")
 		actions.FinishJob(client, tokenResponse, job)
+		actions.SendLogs(client, tokenResponse, job, out)
 
 		return nil
 	},

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/base64"
 	"errors"
 	"os/exec"
 )
@@ -11,4 +12,8 @@ func ExecuteCommand(cmd string) (string, error) {
 		return "", errors.New("Error executing command: " + err.Error())
 	}
 	return string(out), nil
+}
+
+func Base64Encode(json string) string {
+	return base64.StdEncoding.EncodeToString([]byte(json))
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"encoding/base64"
 	"errors"
 	"os/exec"
 )
@@ -12,8 +11,4 @@ func ExecuteCommand(cmd string) (string, error) {
 		return "", errors.New("Error executing command: " + err.Error())
 	}
 	return string(out), nil
-}
-
-func Base64Encode(json string) string {
-	return base64.StdEncoding.EncodeToString([]byte(json))
 }


### PR DESCRIPTION
@DataSnaek here's your work from #4 to upload logs.

Can you update it to send the logs in plaintext instead of base64encoded json?