### PR TITLE
Go modules, structured logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,6 @@
 test:
 	go test ./...
 
-packages:
-	go get github.com/urfave/cli github.com/BurntSushi/toml github.com/robfig/cron
-
 build: backupshq
 
 .PHONY: backupshq

--- a/actions/backups.go
+++ b/actions/backups.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"../api"
-	"../utils"
+	"github.com/backupshq/agent/api"
+	"github.com/backupshq/agent/utils"
 )
 
 func RunBackup(client *api.ApiClient, backup api.Backup) {

--- a/actions/scheduler.go
+++ b/actions/scheduler.go
@@ -3,7 +3,7 @@ package actions
 import (
 	"log"
 
-	"../api"
+	"github.com/backupshq/agent/api"
 	"github.com/robfig/cron"
 )
 

--- a/actions/scheduler.go
+++ b/actions/scheduler.go
@@ -4,7 +4,7 @@ import (
 	"log"
 
 	"github.com/backupshq/agent/api"
-	"github.com/robfig/cron"
+	"github.com/robfig/cron/v3"
 )
 
 func Schedule(client *api.ApiClient, backup api.Backup) *cron.Cron {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/backupshq/agent/actions"
+	"github.com/backupshq/agent/api"
+	"github.com/backupshq/agent/config"
+	"github.com/backupshq/agent/log"
+	"github.com/robfig/cron/v3"
+)
+
+type Agent struct {
+	logger        *log.Logger
+	apiClient     *api.ApiClient
+	config        *config.Config
+	syncFrequency string
+	backups       map[string]api.Backup
+	crons         map[string]*cron.Cron
+}
+
+func Create(c *config.Config, syncFrequency string) *Agent {
+	return &Agent{
+		logger:        log.CreateStdoutLogger(c.LogLevel.Level),
+		apiClient:     api.NewClient(c),
+		config:        c,
+		syncFrequency: syncFrequency,
+		backups:       make(map[string]api.Backup),
+		crons:         make(map[string]*cron.Cron),
+	}
+}
+
+func (a *Agent) update() {
+	a.logger.Debug("Checking for changes to backups...")
+	backups := a.apiClient.ListBackups(api.BACKUP_TYPE_SCHEDULED)
+	a.logger.Debug(fmt.Sprintf("Scheduled backups pulled from the API: %d", len(backups)))
+
+	updatedCount := 0
+	for id := range backups {
+		if a.backups[id] != backups[id] {
+			a.backups[id] = backups[id]
+			if cron, ok := a.crons[id]; ok { // checks if there's an existing cron job for this backup
+				cron.Stop()
+			}
+			a.crons[id] = actions.Schedule(a.apiClient, a.backups[id])
+			updatedCount++
+			a.logger.Debug("Updated backup: " + backups[id].Name)
+		}
+	}
+
+	if updatedCount > 0 {
+		a.logger.Info(fmt.Sprintf("Updated %d backup definitions", updatedCount))
+	} else {
+		a.logger.Debug("No changes detected")
+	}
+}
+
+func (a *Agent) Start() {
+	a.logger.Info("Starting BackupsHQ agent with sync frequency:" + a.syncFrequency)
+
+	a.update()
+
+	cr := cron.New()
+	cr.AddFunc(a.syncFrequency, func() {
+		a.update()
+	})
+	cr.Start()
+
+	time.Sleep(time.Minute * 100)
+}

--- a/api/backup.go
+++ b/api/backup.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"../auth"
+	"github.com/backupshq/agent/auth"
 )
 
 const BACKUP_TYPE_UNMANAGED = 0

--- a/api/backup.go
+++ b/api/backup.go
@@ -10,15 +10,15 @@ import (
 	"github.com/backupshq/agent/auth"
 )
 
-const BACKUP_TYPE_UNMANAGED = 0
-const BACKUP_TYPE_UNSCHEDULED = 1
-const BACKUP_TYPE_SCHEDULED = 2
+const BACKUP_TYPE_UNMANAGED = "unmanaged"
+const BACKUP_TYPE_UNSCHEDULED = "unscheduled"
+const BACKUP_TYPE_SCHEDULED = "scheduled"
 
 type Backup struct {
 	ID          string
 	Name        string
 	Description string
-	Type        int
+	Type        string
 	Command     string
 	Schedule    string
 }
@@ -50,8 +50,8 @@ func (c *ApiClient) GetBackup(backupId string) Backup {
 	return backup
 }
 
-func (c *ApiClient) ListBackups(backupType int) map[string]Backup {
-	req, err := http.NewRequest("GET", "http://localhost:8000/backups/", nil)
+func (c *ApiClient) ListBackups(backupType string) map[string]Backup {
+	req, err := http.NewRequest("GET", "http://localhost:8000/backups", nil)
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}
@@ -74,7 +74,10 @@ func (c *ApiClient) ListBackups(backupType int) map[string]Backup {
 
 	allBackups := make([]Backup, 0)
 	filteredBackupMap := map[string]Backup{}
-	json.Unmarshal(body, &allBackups)
+	err = json.Unmarshal(body, &allBackups)
+	if err != nil {
+		log.Fatal("Error decoding json. ", err)
+	}
 
 	for i, _ := range allBackups {
 		if allBackups[i].Type != backupType {

--- a/api/client.go
+++ b/api/client.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"time"
 
-	"../auth"
-	"../config"
+	"github.com/backupshq/agent/auth"
+	"github.com/backupshq/agent/config"
 )
 
 type ApiClient struct {

--- a/api/job.go
+++ b/api/job.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"../auth"
+	"github.com/backupshq/agent/auth"
 )
 
 type Job struct {

--- a/api/job.go
+++ b/api/job.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -43,7 +44,8 @@ func (c *ApiClient) StartJob(backupId string) Job {
 }
 
 func (c *ApiClient) FinishJob(job Job) {
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/jobs/%s/finish", job.ID), nil)
+	var json = []byte(`{"status":"succeeded"}`)
+	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/jobs/%s/finish", job.ID), bytes.NewBuffer(json))
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}
@@ -54,6 +56,10 @@ func (c *ApiClient) FinishJob(job Job) {
 		log.Fatal("Error reading response. ", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		log.Fatal("Failed to finish job: " + resp.Status)
+	}
 
 	return
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,6 +1,6 @@
 package auth
 
-import "../config"
+import "github.com/backupshq/agent/config"
 import "encoding/json"
 import "io/ioutil"
 import "net/http"

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -26,6 +26,7 @@ func GetAccessToken(config *config.Config) (AccessTokenResponse, error) {
 		"grant_type":    {"client_credentials"},
 		"client_id":     {config.Auth.ClientId},
 		"client_secret": {config.Auth.ClientSecret},
+		"scope":         {"agent"},
 	}
 
 	req, err := http.NewRequest("POST", "http://localhost:8000/auth/token", strings.NewReader(form.Encode()))
@@ -59,4 +60,5 @@ func GetAccessToken(config *config.Config) (AccessTokenResponse, error) {
 
 func AddAuthHeader(req *http.Request, token AccessTokenResponse) {
 	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+	req.Header.Set("Accept", "application/vnd.backupshq.v1+json")
 }

--- a/command/agent.go
+++ b/command/agent.go
@@ -7,7 +7,7 @@ import (
 	"github.com/backupshq/agent/actions"
 	"github.com/backupshq/agent/api"
 	"github.com/backupshq/agent/config"
-	"github.com/robfig/cron"
+	"github.com/robfig/cron/v3"
 	"github.com/urfave/cli"
 )
 

--- a/command/agent.go
+++ b/command/agent.go
@@ -1,39 +1,10 @@
 package command
 
 import (
-	"log"
-	"time"
-
-	"github.com/backupshq/agent/actions"
-	"github.com/backupshq/agent/api"
+	"github.com/backupshq/agent/agent"
 	"github.com/backupshq/agent/config"
-	"github.com/robfig/cron/v3"
 	"github.com/urfave/cli"
 )
-
-func getLatestSchema(client *api.ApiClient, backups map[string]api.Backup, crons map[string]*cron.Cron) (map[string]api.Backup, map[string]*cron.Cron) {
-	log.Println("Checking for changes to backups...")
-	newBackups := client.ListBackups(api.BACKUP_TYPE_SCHEDULED)
-	log.Println("Scheduled backups pulled from the API:", len(newBackups))
-
-	didUpdate := false
-	for id := range newBackups {
-		if backups[id] != newBackups[id] {
-			log.Println("Updated backup: " + newBackups[id].Name)
-			didUpdate = true
-			if cron, ok := crons[id]; ok { // checks if there's an existing cron job for this backup
-				cron.Stop()
-			}
-			crons[id] = actions.Schedule(client, newBackups[id])
-		}
-	}
-
-	if !didUpdate {
-		log.Println("No changes detected")
-	}
-
-	return newBackups, crons
-}
 
 var Agent = cli.Command{
 	Name:  "agent",
@@ -46,20 +17,9 @@ var Agent = cli.Command{
 		},
 	},
 	Action: func(c *cli.Context) error {
-		log.Println("Starting BackupsHQ agent with sync frequency:", c.String("sync"))
-
 		config := config.LoadCli(c)
-
-		client := api.NewClient(config)
-
-		backups, crons := getLatestSchema(client, map[string]api.Backup{}, map[string]*cron.Cron{})
-		cr := cron.New()
-		cr.AddFunc(c.String("sync"), func() {
-			backups, crons = getLatestSchema(client, backups, crons)
-		})
-		cr.Start()
-
-		time.Sleep(time.Minute * 100)
+		agent := agent.Create(config, c.String("sync"))
+		agent.Start()
 
 		return nil
 	},

--- a/command/agent.go
+++ b/command/agent.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"time"
 
-	"../actions"
-	"../api"
-	"../config"
+	"github.com/backupshq/agent/actions"
+	"github.com/backupshq/agent/api"
+	"github.com/backupshq/agent/config"
 	"github.com/robfig/cron"
 	"github.com/urfave/cli"
 )

--- a/command/backup_finish_unmanaged.go
+++ b/command/backup_finish_unmanaged.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"../api"
-	"../config"
+	"github.com/backupshq/agent/api"
+	"github.com/backupshq/agent/config"
 	"github.com/urfave/cli"
 )
 

--- a/command/backup_run.go
+++ b/command/backup_run.go
@@ -3,9 +3,9 @@ package command
 import (
 	"log"
 
-	"../actions"
-	"../api"
-	"../config"
+	"github.com/backupshq/agent/actions"
+	"github.com/backupshq/agent/api"
+	"github.com/backupshq/agent/config"
 	"github.com/urfave/cli"
 )
 

--- a/command/backup_start_unmanaged.go
+++ b/command/backup_start_unmanaged.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"../api"
-	"../config"
+	"github.com/backupshq/agent/api"
+	"github.com/backupshq/agent/config"
 	"github.com/urfave/cli"
 )
 

--- a/command/config_show.go
+++ b/command/config_show.go
@@ -2,8 +2,8 @@ package command
 
 import "fmt"
 import "github.com/urfave/cli"
-import "../utils"
-import "../config"
+import "github.com/backupshq/agent/utils"
+import "github.com/backupshq/agent/config"
 import "io/ioutil"
 import "log"
 

--- a/command/config_validate.go
+++ b/command/config_validate.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"../config"
-	"../utils"
+	"github.com/backupshq/agent/config"
+	"github.com/backupshq/agent/utils"
 	"github.com/urfave/cli"
 )
 

--- a/config/cli.go
+++ b/config/cli.go
@@ -3,7 +3,7 @@ package config
 import (
 	"log"
 
-	"../utils"
+	"github.com/backupshq/agent/utils"
 
 	"github.com/urfave/cli"
 )

--- a/config/example.toml
+++ b/config/example.toml
@@ -1,3 +1,5 @@
+log_level = "info"
+
 [auth]
 client_id = "id"
 client_secret = "secret"

--- a/config/loader.go
+++ b/config/loader.go
@@ -3,11 +3,13 @@ package config
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"html/template"
 	"io/ioutil"
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/backupshq/agent/log"
 )
 
 type Config struct {
@@ -15,6 +17,29 @@ type Config struct {
 		ClientId     string `toml:"client_id"`
 		ClientSecret string `toml:"client_secret"`
 	}
+	LogLevel LogLevel `toml:"log_level"`
+}
+
+type LogLevel struct {
+	Level int
+	Label string
+}
+
+var logLevels = map[string]int{
+	"debug": log.Debug,
+	"info":  log.Info,
+	"warn":  log.Warn,
+	"error": log.Error,
+}
+
+func (l *LogLevel) UnmarshalText(text []byte) error {
+	value := string(text)
+	if level, ok := logLevels[value]; ok {
+		l.Level = level
+		l.Label = value
+		return nil
+	}
+	return errors.New(fmt.Sprintf("Unknown log level '%s'. Valid levels are 'debug', 'info', 'warn', and 'error'.", value))
 }
 
 type ConfigLoader struct {

--- a/config/loader.go
+++ b/config/loader.go
@@ -80,7 +80,12 @@ func (l *ConfigLoader) LoadString(tomlText string) (*Config, error) {
 		return nil, err
 	}
 
-	var config Config
+	config := Config{
+		LogLevel: LogLevel{
+			Level: log.Info,
+			Label: "info",
+		},
+	}
 	metadata, err := toml.Decode(tomlText, &config)
 	if err != nil {
 		return nil, errors.New("TOML syntax error: " + err.Error())

--- a/config/loader.go
+++ b/config/loader.go
@@ -22,7 +22,6 @@ type Config struct {
 
 type LogLevel struct {
 	Level int
-	Label string
 }
 
 var logLevels = map[string]int{
@@ -36,7 +35,6 @@ func (l *LogLevel) UnmarshalText(text []byte) error {
 	value := string(text)
 	if level, ok := logLevels[value]; ok {
 		l.Level = level
-		l.Label = value
 		return nil
 	}
 	return errors.New(fmt.Sprintf("Unknown log level '%s'. Valid levels are 'debug', 'info', 'warn', and 'error'.", value))
@@ -83,7 +81,6 @@ func (l *ConfigLoader) LoadString(tomlText string) (*Config, error) {
 	config := Config{
 		LogLevel: LogLevel{
 			Level: log.Info,
-			Label: "info",
 		},
 	}
 	metadata, err := toml.Decode(tomlText, &config)

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"strings"
 	"testing"
+
+	"github.com/backupshq/agent/log"
 )
 
 func TestString(t *testing.T) {
@@ -54,6 +56,34 @@ Client_Secret = 'secret'
 		}
 		if config.Auth.ClientSecret != "secret" {
 			t.Errorf("got %q want %q", config.Auth.ClientSecret, "secret")
+		}
+	})
+
+	t.Run("load log level", func(t *testing.T) {
+		loader := NewConfigLoader(map[string]string{})
+		config, err := loader.LoadString(`
+log_level = 'info'
+`)
+		if err != nil {
+			t.Errorf("expected a Config struct to be created without error, got %q", err.Error())
+			return
+		}
+		if config.LogLevel.Level != log.Info {
+			t.Errorf("got %d want %d", config.LogLevel.Level, log.Info)
+		}
+	})
+
+	t.Run("load invalid log level", func(t *testing.T) {
+		loader := NewConfigLoader(map[string]string{})
+		_, err := loader.LoadString(`
+log_level = 'critical'
+`)
+		if err == nil {
+			t.Errorf("expected an error loading config")
+			return
+		}
+		if err.Error() != "TOML syntax error: Unknown log level 'critical'. Valid levels are 'debug', 'info', 'warn', and 'error'." {
+			t.Errorf("unexpected error message: %q", err.Error())
 		}
 	})
 
@@ -160,7 +190,7 @@ func TestFile(t *testing.T) {
 		config, err := loader.LoadFile("example.toml")
 
 		if err != nil {
-			t.Errorf("file should be loaded successfully")
+			t.Errorf("file should be loaded successfully, got error %q", err)
 			return
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/backupshq/agent
+
+go 1.14
+
+require (
+	github.com/BurntSushi/toml v0.3.1
+	github.com/robfig/cron v1.2.0
+	github.com/urfave/cli v1.22.4
+)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.14
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/robfig/cron v1.2.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/urfave/cli v1.22.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
+github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -2,9 +2,10 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
-github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=

--- a/log/format.go
+++ b/log/format.go
@@ -5,19 +5,18 @@ import (
 	"time"
 )
 
+var levels = map[int]string{
+	Debug: "DEBUG",
+	Info:  "INFO",
+	Warn:  "WARN",
+	Error: "ERROR",
+}
+
 func levelLabel(level int) string {
-	switch level {
-	case Debug:
-		return "DEBUG"
-	case Info:
-		return "INFO"
-	case Warn:
-		return "WARN"
-	case Error:
-		return "ERROR"
-	default:
-		return ""
+	if level, ok := levels[level]; ok {
+		return level
 	}
+	return ""
 }
 
 func withTime(message string) string {

--- a/log/format.go
+++ b/log/format.go
@@ -1,0 +1,32 @@
+package log
+
+import (
+	"fmt"
+	"time"
+)
+
+func levelLabel(level int) string {
+	switch level {
+	case Debug:
+		return "DEBUG"
+	case Info:
+		return "INFO"
+	case Warn:
+		return "WARN"
+	case Error:
+		return "ERROR"
+	default:
+		return ""
+	}
+}
+
+func withTime(message string) string {
+	return fmt.Sprintf("%s %s", time.Now().UTC().Format(time.RFC3339), message)
+}
+
+func withLevel(level int, message string) string {
+	label := fmt.Sprintf("[%s]", levelLabel(level))
+	label += " "
+
+	return fmt.Sprintf("%s %s", label[:7], message)
+}

--- a/log/format_test.go
+++ b/log/format_test.go
@@ -1,0 +1,20 @@
+package log
+
+import (
+	"testing"
+)
+
+func assertEquals(t *testing.T, expected string, actual string) {
+	if actual != expected {
+		t.Errorf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestWithLevel(t *testing.T) {
+	t.Run("white space is padded", func(t *testing.T) {
+		assertEquals(t, "[DEBUG] Hello world", withLevel(Debug, "Hello world"))
+		assertEquals(t, "[INFO]  Hello world", withLevel(Info, "Hello world"))
+		assertEquals(t, "[WARN]  Hello world", withLevel(Warn, "Hello world"))
+		assertEquals(t, "[ERROR] Hello world", withLevel(Error, "Hello world"))
+	})
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,10 +1,9 @@
 package log
 
-const Debug = 5
-const Info = 4
-const Warn = 3
-const Error = 2
-const Fatal = 1
+const Debug = 4
+const Info = 3
+const Warn = 2
+const Error = 1
 
 type Logger struct {
 	level  int
@@ -33,10 +32,5 @@ func (l *Logger) Warn(message string) {
 func (l *Logger) Error(message string) {
 	if l.level >= Error {
 		l.writer.Write(Error, message)
-	}
-}
-func (l *Logger) Fatal(message string) {
-	if l.level >= Fatal {
-		l.writer.Write(Fatal, message)
 	}
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,0 +1,42 @@
+package log
+
+const Debug = 5
+const Info = 4
+const Warn = 3
+const Error = 2
+const Fatal = 1
+
+type Logger struct {
+	level  int
+	writer Writer
+}
+
+type Writer interface {
+	Write(level int, message string)
+}
+
+func (l *Logger) Debug(message string) {
+	if l.level >= Debug {
+		l.writer.Write(Debug, message)
+	}
+}
+func (l *Logger) Info(message string) {
+	if l.level >= Info {
+		l.writer.Write(Info, message)
+	}
+}
+func (l *Logger) Warn(message string) {
+	if l.level >= Warn {
+		l.writer.Write(Warn, message)
+	}
+}
+func (l *Logger) Error(message string) {
+	if l.level >= Error {
+		l.writer.Write(Error, message)
+	}
+}
+func (l *Logger) Fatal(message string) {
+	if l.level >= Fatal {
+		l.writer.Write(Fatal, message)
+	}
+}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -21,7 +21,6 @@ func testLog(l *Logger) {
 	l.Info("Test info")
 	l.Warn("Test warn")
 	l.Error("Test error")
-	l.Fatal("Test fatal")
 }
 
 func assertLog(t *testing.T, log MockLog, expectedMessage string) {
@@ -39,8 +38,8 @@ func TestLogger(t *testing.T) {
 		}
 		testLog(l)
 
-		if len(w.messages) != 5 {
-			t.Errorf("expected 5 messages, got %d", len(w.messages))
+		if len(w.messages) != 4 {
+			t.Errorf("expected 4 messages, got %d", len(w.messages))
 			return
 		}
 
@@ -48,7 +47,6 @@ func TestLogger(t *testing.T) {
 		assertLog(t, w.messages[1], "Test info")
 		assertLog(t, w.messages[2], "Test warn")
 		assertLog(t, w.messages[3], "Test error")
-		assertLog(t, w.messages[4], "Test fatal")
 	})
 
 	t.Run("Test info", func(t *testing.T) {
@@ -60,15 +58,14 @@ func TestLogger(t *testing.T) {
 
 		testLog(l)
 
-		if len(w.messages) != 4 {
-			t.Errorf("expected 4 messages, got %d", len(w.messages))
+		if len(w.messages) != 3 {
+			t.Errorf("expected 3 messages, got %d", len(w.messages))
 			return
 		}
 
 		assertLog(t, w.messages[0], "Test info")
 		assertLog(t, w.messages[1], "Test warn")
 		assertLog(t, w.messages[2], "Test error")
-		assertLog(t, w.messages[3], "Test fatal")
 	})
 
 	t.Run("Test warn", func(t *testing.T) {
@@ -80,14 +77,13 @@ func TestLogger(t *testing.T) {
 
 		testLog(l)
 
-		if len(w.messages) != 3 {
-			t.Errorf("expected 3 messages, got %d", len(w.messages))
+		if len(w.messages) != 2 {
+			t.Errorf("expected 2 messages, got %d", len(w.messages))
 			return
 		}
 
 		assertLog(t, w.messages[0], "Test warn")
 		assertLog(t, w.messages[1], "Test error")
-		assertLog(t, w.messages[2], "Test fatal")
 	})
 
 	t.Run("Test error", func(t *testing.T) {
@@ -99,29 +95,11 @@ func TestLogger(t *testing.T) {
 
 		testLog(l)
 
-		if len(w.messages) != 2 {
-			t.Errorf("expected 2 messages, got %d", len(w.messages))
+		if len(w.messages) != 1 {
+			t.Errorf("expected 1 message, got %d", len(w.messages))
 			return
 		}
 
 		assertLog(t, w.messages[0], "Test error")
-		assertLog(t, w.messages[1], "Test fatal")
-	})
-
-	t.Run("Test fatal", func(t *testing.T) {
-		w := &MockWriter{}
-		l := &Logger{
-			level:  Fatal,
-			writer: w,
-		}
-
-		testLog(l)
-
-		if len(w.messages) != 1 {
-			t.Fatalf("expected 1 message, got %d", len(w.messages))
-			return
-		}
-
-		assertLog(t, w.messages[0], "Test fatal")
 	})
 }

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,0 +1,127 @@
+package log
+
+import (
+	"testing"
+)
+
+type MockLog struct {
+	level   int
+	message string
+}
+type MockWriter struct {
+	messages []MockLog
+}
+
+func (w *MockWriter) Write(level int, message string) {
+	w.messages = append(w.messages, MockLog{level, message})
+}
+
+func testLog(l *Logger) {
+	l.Debug("Test debug")
+	l.Info("Test info")
+	l.Warn("Test warn")
+	l.Error("Test error")
+	l.Fatal("Test fatal")
+}
+
+func assertLog(t *testing.T, log MockLog, expectedMessage string) {
+	if log.message != expectedMessage {
+		t.Errorf("wrong message logged, expected %q but got %q", expectedMessage, log.message)
+	}
+}
+
+func TestLogger(t *testing.T) {
+	t.Run("Test debug", func(t *testing.T) {
+		w := &MockWriter{}
+		l := &Logger{
+			level:  Debug,
+			writer: w,
+		}
+		testLog(l)
+
+		if len(w.messages) != 5 {
+			t.Errorf("expected 5 messages, got %d", len(w.messages))
+			return
+		}
+
+		assertLog(t, w.messages[0], "Test debug")
+		assertLog(t, w.messages[1], "Test info")
+		assertLog(t, w.messages[2], "Test warn")
+		assertLog(t, w.messages[3], "Test error")
+		assertLog(t, w.messages[4], "Test fatal")
+	})
+
+	t.Run("Test info", func(t *testing.T) {
+		w := &MockWriter{}
+		l := &Logger{
+			level:  Info,
+			writer: w,
+		}
+
+		testLog(l)
+
+		if len(w.messages) != 4 {
+			t.Errorf("expected 4 messages, got %d", len(w.messages))
+			return
+		}
+
+		assertLog(t, w.messages[0], "Test info")
+		assertLog(t, w.messages[1], "Test warn")
+		assertLog(t, w.messages[2], "Test error")
+		assertLog(t, w.messages[3], "Test fatal")
+	})
+
+	t.Run("Test warn", func(t *testing.T) {
+		w := &MockWriter{}
+		l := &Logger{
+			level:  Warn,
+			writer: w,
+		}
+
+		testLog(l)
+
+		if len(w.messages) != 3 {
+			t.Errorf("expected 3 messages, got %d", len(w.messages))
+			return
+		}
+
+		assertLog(t, w.messages[0], "Test warn")
+		assertLog(t, w.messages[1], "Test error")
+		assertLog(t, w.messages[2], "Test fatal")
+	})
+
+	t.Run("Test error", func(t *testing.T) {
+		w := &MockWriter{}
+		l := &Logger{
+			level:  Error,
+			writer: w,
+		}
+
+		testLog(l)
+
+		if len(w.messages) != 2 {
+			t.Errorf("expected 2 messages, got %d", len(w.messages))
+			return
+		}
+
+		assertLog(t, w.messages[0], "Test error")
+		assertLog(t, w.messages[1], "Test fatal")
+	})
+
+	t.Run("Test fatal", func(t *testing.T) {
+		w := &MockWriter{}
+		l := &Logger{
+			level:  Fatal,
+			writer: w,
+		}
+
+		testLog(l)
+
+		if len(w.messages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(w.messages))
+			return
+		}
+
+		assertLog(t, w.messages[0], "Test fatal")
+	})
+}

--- a/log/stdout.go
+++ b/log/stdout.go
@@ -1,0 +1,19 @@
+package log
+
+import (
+	"fmt"
+)
+
+type StdoutWriter struct {
+}
+
+func (w *StdoutWriter) Write(level int, message string) {
+	fmt.Println(withTime(withLevel(level, message)))
+}
+
+func CreateStdoutLogger(level int) *Logger {
+	return &Logger{
+		level:  level,
+		writer: &StdoutWriter{},
+	}
+}

--- a/log/stdout_test.go
+++ b/log/stdout_test.go
@@ -1,0 +1,19 @@
+package log
+
+import (
+	"testing"
+)
+
+func TestStdoutLogger(t *testing.T) {
+	t.Run("Logger has correct level", func(t *testing.T) {
+		l := CreateStdoutLogger(Debug)
+		if l.level != Debug {
+			t.Errorf("Expected level to be %d but got %d", Debug, l.level)
+		}
+
+		l = CreateStdoutLogger(Error)
+		if l.level != Error {
+			t.Errorf("Expected level to be %d but got %d", Error, l.level)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"./command"
+	"github.com/backupshq/agent/command"
 	"github.com/urfave/cli"
 )
 


### PR DESCRIPTION
* Use `go mod` for dependencies
* Get the agent working again with the API (somewhat)
* Add a logger interface with 4 levels: debug, info, warn, error. Inject into the code instead of calling `fmt.Println()` or `log.Fatal()` everywhere.
* General cleanups and restructure.

Ping @mitchelljy (not expecting your review here)