### PR TITLE
Configurable API server and general cleanups

### DIFF
--- a/actions/backups.go
+++ b/actions/backups.go
@@ -14,15 +14,17 @@ func RunBackup(client *api.ApiClient, backup api.Backup) {
 
 	log.Println("Running backup...")
 	log.Printf("Command: %s\n\n", backup.Command)
+	status := "succeeded"
 	out, err := utils.ExecuteCommand(backup.Command)
 	if err != nil {
 		// In the future we can use this block to determine status code, but for now just send the error the the API
 		log.Println(err)
 		out = err.Error()
+		status = "failed"
 	}
 	fmt.Println(out)
 
 	log.Println("Publishing results to API.")
-	client.FinishJob(job)
+	client.FinishJob(job, status)
 	client.SendLogs(job, out)
 }

--- a/actions/backups.go
+++ b/actions/backups.go
@@ -21,7 +21,7 @@ func RunBackup(client *api.ApiClient, backup api.Backup, logger *log.Logger) {
 		out = err.Error()
 		status = "failed"
 	}
-	logger.Debug(out)
+	logger.Debug("\n" + out)
 
 	logger.Debug("Publishing job result to the API.")
 	client.FinishJob(job, status)

--- a/actions/backups.go
+++ b/actions/backups.go
@@ -2,29 +2,28 @@ package actions
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/backupshq/agent/api"
+	"github.com/backupshq/agent/log"
 	"github.com/backupshq/agent/utils"
 )
 
-func RunBackup(client *api.ApiClient, backup api.Backup) {
+func RunBackup(client *api.ApiClient, backup api.Backup, logger *log.Logger) {
 	job := client.StartJob(backup.ID)
-	log.Printf("Started a new job with id %q.\n", job.ID)
+	logger.Info(fmt.Sprintf("Starting a new job with id %q.", job.ID))
 
-	log.Println("Running backup...")
-	log.Printf("Command: %s\n\n", backup.Command)
+	logger.Debug(fmt.Sprintf(`Running backup command: "%s"`, backup.Command))
 	status := "succeeded"
 	out, err := utils.ExecuteCommand(backup.Command)
 	if err != nil {
 		// In the future we can use this block to determine status code, but for now just send the error the the API
-		log.Println(err)
+		logger.Warn(err.Error())
 		out = err.Error()
 		status = "failed"
 	}
-	fmt.Println(out)
+	logger.Debug(out)
 
-	log.Println("Publishing results to API.")
+	logger.Debug("Publishing job result to the API.")
 	client.FinishJob(job, status)
 	client.SendLogs(job, out)
 }

--- a/actions/scheduler.go
+++ b/actions/scheduler.go
@@ -1,16 +1,15 @@
 package actions
 
 import (
-	"log"
-
 	"github.com/backupshq/agent/api"
+	"github.com/backupshq/agent/log"
 	"github.com/robfig/cron/v3"
 )
 
-func Schedule(client *api.ApiClient, backup api.Backup) *cron.Cron {
-	log.Println("Schedule " + backup.Name + " for " + backup.Schedule)
+func Schedule(client *api.ApiClient, backup api.Backup, logger *log.Logger) *cron.Cron {
+	logger.Info("Schedule " + backup.Name + " for " + backup.Schedule)
 	c := cron.New()
-	c.AddFunc(backup.Schedule, func() { RunBackup(client, backup) })
+	c.AddFunc(backup.Schedule, func() { RunBackup(client, backup, logger) })
 	c.Start()
 	return c
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -63,6 +63,7 @@ Starting BackupsHQ agent
 ========================
 `)
 	a.apiClient.Authenticate()
+	a.logger.Debug(fmt.Sprintf(`Principal: %s`, a.apiClient.PrincipalId))
 
 	a.logger.Info("Sync frequency: " + a.syncFrequency)
 	a.update()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -17,6 +17,7 @@ type Agent struct {
 	config        *config.Config
 	syncFrequency string
 	principal     api.Principal
+	account       api.Account
 	backups       map[string]api.Backup
 	crons         map[string]*cron.Cron
 }
@@ -64,8 +65,11 @@ Starting BackupsHQ agent
 ========================
 `)
 	a.apiClient.Authenticate()
-	a.principal = a.apiClient.GetPrincipal(a.apiClient.PrincipalId)
+	tokenInfo := a.apiClient.GetCurrentToken()
+	a.principal = a.apiClient.GetPrincipal(tokenInfo.PrincipalId)
 	a.logger.Info(fmt.Sprintf(`Authenticated as principal %s "%s"`, a.principal.ID, a.principal.Name))
+	a.account = a.apiClient.GetAccount(tokenInfo.AccountId)
+	a.logger.Info(fmt.Sprintf(`This agent belongs to account %s "%s"`, a.account.ID, a.account.Name))
 
 	a.logger.Info("Sync frequency: " + a.syncFrequency)
 	a.update()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -43,7 +43,7 @@ func (a *Agent) update() {
 			if cron, ok := a.crons[id]; ok { // checks if there's an existing cron job for this backup
 				cron.Stop()
 			}
-			a.crons[id] = actions.Schedule(a.apiClient, a.backups[id])
+			a.crons[id] = actions.Schedule(a.apiClient, a.backups[id], a.logger)
 			updatedCount++
 			a.logger.Debug("Updated backup: " + backups[id].Name)
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -57,10 +57,15 @@ func (a *Agent) update() {
 }
 
 func (a *Agent) Start() {
-	a.logger.Info("Starting BackupsHQ agent with sync frequency:" + a.syncFrequency)
+	a.logger.Info(`
+========================
+Starting BackupsHQ agent
+========================
+`)
+	a.apiClient.Authenticate()
 
+	a.logger.Info("Sync frequency: " + a.syncFrequency)
 	a.update()
-
 	cr := cron.New()
 	cr.AddFunc(a.syncFrequency, func() {
 		a.update()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -16,6 +16,7 @@ type Agent struct {
 	apiClient     *api.ApiClient
 	config        *config.Config
 	syncFrequency string
+	principal     api.Principal
 	backups       map[string]api.Backup
 	crons         map[string]*cron.Cron
 }
@@ -63,7 +64,8 @@ Starting BackupsHQ agent
 ========================
 `)
 	a.apiClient.Authenticate()
-	a.logger.Debug(fmt.Sprintf(`Principal: %s`, a.apiClient.PrincipalId))
+	a.principal = a.apiClient.GetPrincipal(a.apiClient.PrincipalId)
+	a.logger.Info(fmt.Sprintf(`Authenticated as principal %s "%s"`, a.principal.ID, a.principal.Name))
 
 	a.logger.Info("Sync frequency: " + a.syncFrequency)
 	a.update()

--- a/api/account.go
+++ b/api/account.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+)
+
+type Account struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
+func (c *ApiClient) GetAccount(id string) Account {
+	req, err := c.get(fmt.Sprintf("/accounts/%s", id))
+	if err != nil {
+		log.Fatal("Error creating request. ", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		log.Fatal("Error reading response. ", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		log.Fatal("Unable to get account: HTTP " + resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal("Error reading body. ", err)
+	}
+
+	var account Account
+	err = json.Unmarshal(body, &account)
+
+	return account
+}

--- a/api/auth.go
+++ b/api/auth.go
@@ -61,7 +61,6 @@ func (c *ApiClient) Authenticate() {
 
 	c.accessToken = token
 	c.accessTokenExpiry, _ = utils.GetAccessTokenExpiry(token)
-	c.PrincipalId, _ = utils.GetAccessTokenPrincipalId(token)
 }
 
 func (c *ApiClient) AddAuthHeader(req *http.Request) {

--- a/api/auth.go
+++ b/api/auth.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/backupshq/agent/auth"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func (c *ApiClient) GetAccessToken() (string, error) {
+	form := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {c.credentials.clientId},
+		"client_secret": {c.credentials.clientSecret},
+		"scope":         {"agent"},
+	}
+
+	req, err := http.NewRequest("POST", c.server+"/auth/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", errors.New("Error reading request: " + err.Error())
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", errors.New("Error reading response: " + err.Error())
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", errors.New("Unable to retrieve access token: HTTP " + resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.New("Error reading JSON response body: " + string(body))
+	}
+
+	response := struct {
+		Token string `json:"access_token"`
+	}{}
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return "", err
+	}
+
+	return response.Token, nil
+}
+
+func (c *ApiClient) Authenticate() {
+	token, err := c.GetAccessToken()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	c.accessToken = token
+	c.accessTokenExpiry = auth.GetTokenExpiry(token)
+	c.PrincipalId = auth.GetTokenPrincipal(token)
+}
+
+func (c *ApiClient) AddAuthHeader(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+c.accessToken)
+	req.Header.Set("Accept", fmt.Sprintf("application/vnd.backupshq.v%d+json", c.version))
+}

--- a/api/auth.go
+++ b/api/auth.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/backupshq/agent/auth"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/backupshq/agent/utils"
 )
 
 func (c *ApiClient) GetAccessToken() (string, error) {
@@ -59,8 +60,8 @@ func (c *ApiClient) Authenticate() {
 	}
 
 	c.accessToken = token
-	c.accessTokenExpiry = auth.GetTokenExpiry(token)
-	c.PrincipalId = auth.GetTokenPrincipal(token)
+	c.accessTokenExpiry, _ = utils.GetAccessTokenExpiry(token)
+	c.PrincipalId, _ = utils.GetAccessTokenPrincipalId(token)
 }
 
 func (c *ApiClient) AddAuthHeader(req *http.Request) {

--- a/api/backup.go
+++ b/api/backup.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net/http"
-
-	"github.com/backupshq/agent/auth"
 )
 
 const BACKUP_TYPE_UNMANAGED = "unmanaged"
@@ -24,11 +21,10 @@ type Backup struct {
 }
 
 func (c *ApiClient) GetBackup(backupId string) Backup {
-	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:8000/backups/%s", backupId), nil)
+	req, err := c.get(fmt.Sprintf("/backups/%s", backupId))
 	if err != nil {
-		log.Fatal("Error reading request. ", err)
+		log.Fatal("Error creating request. ", err)
 	}
-	auth.AddAuthHeader(req, c.tokenResponse)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -51,11 +47,10 @@ func (c *ApiClient) GetBackup(backupId string) Backup {
 }
 
 func (c *ApiClient) ListBackups(backupType string) map[string]Backup {
-	req, err := http.NewRequest("GET", "http://localhost:8000/backups", nil)
+	req, err := c.get("/backups")
 	if err != nil {
-		log.Fatal("Error reading request. ", err)
+		log.Fatal("Error creating request. ", err)
 	}
-	auth.AddAuthHeader(req, c.tokenResponse)
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/api/client.go
+++ b/api/client.go
@@ -2,10 +2,10 @@ package api
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/backupshq/agent/config"
-	"strings"
 )
 
 type credentials struct {
@@ -19,7 +19,7 @@ type ApiClient struct {
 	server            string
 	version           int
 	accessToken       string
-	accessTokenExpiry int
+	accessTokenExpiry time.Time
 	PrincipalId       string
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -20,7 +20,6 @@ type ApiClient struct {
 	version           int
 	accessToken       string
 	accessTokenExpiry time.Time
-	PrincipalId       string
 }
 
 func NewClient(config *config.Config) *ApiClient {

--- a/api/client.go
+++ b/api/client.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/backupshq/agent/auth"
 	"github.com/backupshq/agent/config"
+	"strings"
 )
 
 type ApiClient struct {
 	client        *http.Client
 	tokenResponse auth.AccessTokenResponse
+	server        string
 }
 
 func NewClient(config *config.Config) *ApiClient {
@@ -24,5 +26,20 @@ func NewClient(config *config.Config) *ApiClient {
 		Timeout: time.Second * 3,
 	}
 
-	return &ApiClient{client: client, tokenResponse: tokenResponse}
+	return &ApiClient{
+		client:        client,
+		tokenResponse: tokenResponse,
+		server:        config.ApiServer,
+	}
+}
+
+func (c *ApiClient) get(path string) (*http.Request, error) {
+	path = "/" + strings.TrimLeft(path, "/")
+	req, err := http.NewRequest("GET", c.server+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	auth.AddAuthHeader(req, c.tokenResponse)
+
+	return req, nil
 }

--- a/api/job.go
+++ b/api/job.go
@@ -8,8 +8,6 @@ import (
 	"log"
 	"net/http"
 	"strings"
-
-	"github.com/backupshq/agent/auth"
 )
 
 type Job struct {
@@ -21,7 +19,7 @@ func (c *ApiClient) StartJob(backupId string) Job {
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}
-	auth.AddAuthHeader(req, c.tokenResponse)
+	c.AddAuthHeader(req)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -49,7 +47,7 @@ func (c *ApiClient) FinishJob(job Job, status string) {
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}
-	auth.AddAuthHeader(req, c.tokenResponse)
+	c.AddAuthHeader(req)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -71,7 +69,7 @@ func (c *ApiClient) SendLogs(job Job, logStr string) {
 	}
 	req.Header.Set("Content-Type", "text/plain")
 
-	auth.AddAuthHeader(req, c.tokenResponse)
+	c.AddAuthHeader(req)
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/api/job.go
+++ b/api/job.go
@@ -43,8 +43,8 @@ func (c *ApiClient) StartJob(backupId string) Job {
 	return startedJob
 }
 
-func (c *ApiClient) FinishJob(job Job) {
-	var json = []byte(`{"status":"succeeded"}`)
+func (c *ApiClient) FinishJob(job Job, status string) {
+	var json = []byte(fmt.Sprintf(`{"status":"%s"}`, status))
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/jobs/%s/finish", c.server, job.ID), bytes.NewBuffer(json))
 	if err != nil {
 		log.Fatal("Error reading request. ", err)

--- a/api/job.go
+++ b/api/job.go
@@ -17,7 +17,7 @@ type Job struct {
 }
 
 func (c *ApiClient) StartJob(backupId string) Job {
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/backups/%s/start", backupId), nil)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/backups/%s/start", c.server, backupId), nil)
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}
@@ -45,7 +45,7 @@ func (c *ApiClient) StartJob(backupId string) Job {
 
 func (c *ApiClient) FinishJob(job Job) {
 	var json = []byte(`{"status":"succeeded"}`)
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/jobs/%s/finish", job.ID), bytes.NewBuffer(json))
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/jobs/%s/finish", c.server, job.ID), bytes.NewBuffer(json))
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}
@@ -65,7 +65,7 @@ func (c *ApiClient) FinishJob(job Job) {
 }
 
 func (c *ApiClient) SendLogs(job Job, logStr string) {
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:8000/jobs/%s/logs", job.ID), strings.NewReader(logStr))
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/jobs/%s/logs", c.server, job.ID), strings.NewReader(logStr))
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}

--- a/api/principal.go
+++ b/api/principal.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+)
+
+type Principal struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
+func (c *ApiClient) GetPrincipal(id string) Principal {
+	req, err := c.get(fmt.Sprintf("/principals/%s", id))
+	if err != nil {
+		log.Fatal("Error creating request. ", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		log.Fatal("Error reading response. ", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		log.Fatal("Unable to get principal: HTTP " + resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal("Error reading body. ", err)
+	}
+
+	var principal Principal
+	err = json.Unmarshal(body, &principal)
+
+	return principal
+}

--- a/api/token.go
+++ b/api/token.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+)
+
+type TokenInfo struct {
+	ID          string `json:"id"`
+	PrincipalId string `json:"principal_id"`
+	AccountId   string `json:"account_id"`
+}
+
+func (c *ApiClient) GetCurrentToken() TokenInfo {
+	req, err := c.get("/tokens/self")
+	if err != nil {
+		log.Fatal("Error creating request. ", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		log.Fatal("Error reading response. ", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		log.Fatal("Unable to get token: HTTP " + resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal("Error reading body. ", err)
+	}
+
+	var token TokenInfo
+	err = json.Unmarshal(body, &token)
+
+	return token
+}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,65 +1,9 @@
 package auth
 
-import (
-	"encoding/json"
-	"errors"
-	"io/ioutil"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
-)
-
-type AccessTokenResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	ExpiresIn   int    `json:"expires_in"`
-	Scope       string `json:"scope"`
+func GetTokenExpiry(token string) int {
+	return 3600
 }
 
-func GetAccessToken(clientId string, clientSecret string, endpoint string) (AccessTokenResponse, error) {
-	client := &http.Client{
-		Timeout: time.Second * 3,
-	}
-	tokenResponse := AccessTokenResponse{}
-
-	form := url.Values{
-		"grant_type":    {"client_credentials"},
-		"client_id":     {clientId},
-		"client_secret": {clientSecret},
-		"scope":         {"agent"},
-	}
-
-	req, err := http.NewRequest("POST", endpoint, strings.NewReader(form.Encode()))
-	if err != nil {
-		return tokenResponse, errors.New("Error reading request: " + err.Error())
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return tokenResponse, errors.New("Error reading response: " + err.Error())
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return tokenResponse, errors.New("Unable to retrieve access token: HTTP " + resp.Status)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return tokenResponse, errors.New("Error reading JSON response body: " + string(body))
-	}
-
-	err = json.Unmarshal(body, &tokenResponse)
-	if err != nil {
-		return tokenResponse, err
-	}
-
-	return tokenResponse, nil
-}
-
-func AddAuthHeader(req *http.Request, token AccessTokenResponse) {
-	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
-	req.Header.Set("Accept", "application/vnd.backupshq.v1+json")
+func GetTokenPrincipal(token string) string {
+	return "b16421d5-9ae7-41d0-ad17-38b735c96307"
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,9 +1,0 @@
-package auth
-
-func GetTokenExpiry(token string) int {
-	return 3600
-}
-
-func GetTokenPrincipal(token string) string {
-	return "b16421d5-9ae7-41d0-ad17-38b735c96307"
-}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,22 +1,23 @@
 package auth
 
-import "github.com/backupshq/agent/config"
-import "encoding/json"
-import "io/ioutil"
-import "net/http"
-import "net/url"
-import "strings"
-import "errors"
-import "time"
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
 
 type AccessTokenResponse struct {
 	AccessToken string `json:"access_token"`
 	TokenType   string `json:"token_type"`
-	ExpiresIn   int    `json:"expires_id"`
+	ExpiresIn   int    `json:"expires_in"`
 	Scope       string `json:"scope"`
 }
 
-func GetAccessToken(config *config.Config) (AccessTokenResponse, error) {
+func GetAccessToken(clientId string, clientSecret string, endpoint string) (AccessTokenResponse, error) {
 	client := &http.Client{
 		Timeout: time.Second * 3,
 	}
@@ -24,12 +25,12 @@ func GetAccessToken(config *config.Config) (AccessTokenResponse, error) {
 
 	form := url.Values{
 		"grant_type":    {"client_credentials"},
-		"client_id":     {config.Auth.ClientId},
-		"client_secret": {config.Auth.ClientSecret},
+		"client_id":     {clientId},
+		"client_secret": {clientSecret},
 		"scope":         {"agent"},
 	}
 
-	req, err := http.NewRequest("POST", config.ApiServer+"/auth/token", strings.NewReader(form.Encode()))
+	req, err := http.NewRequest("POST", endpoint, strings.NewReader(form.Encode()))
 	if err != nil {
 		return tokenResponse, errors.New("Error reading request: " + err.Error())
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -29,7 +29,7 @@ func GetAccessToken(config *config.Config) (AccessTokenResponse, error) {
 		"scope":         {"agent"},
 	}
 
-	req, err := http.NewRequest("POST", "http://localhost:8000/auth/token", strings.NewReader(form.Encode()))
+	req, err := http.NewRequest("POST", config.ApiServer+"/auth/token", strings.NewReader(form.Encode()))
 	if err != nil {
 		return tokenResponse, errors.New("Error reading request: " + err.Error())
 	}

--- a/command/backup_finish_unmanaged.go
+++ b/command/backup_finish_unmanaged.go
@@ -36,7 +36,7 @@ var BackupFinishUnmanaged = cli.Command{
 		client := api.NewClient(config)
 
 		job := api.Job{ID: c.Args().Get(0)}
-		client.FinishJob(job)
+		client.FinishJob(job, "succeeded")
 		log.Printf("Finished Job: %q.\n", job.ID)
 
 		return nil

--- a/command/backup_run.go
+++ b/command/backup_run.go
@@ -1,11 +1,10 @@
 package command
 
 import (
-	"log"
-
 	"github.com/backupshq/agent/actions"
 	"github.com/backupshq/agent/api"
 	"github.com/backupshq/agent/config"
+	"github.com/backupshq/agent/log"
 	"github.com/urfave/cli"
 )
 
@@ -15,14 +14,15 @@ var BackupRun = cli.Command{
 	Action: func(c *cli.Context) error {
 		config := config.LoadCli(c)
 
+		logger := log.CreateStdoutLogger(config.LogLevel.Level)
 		client := api.NewClient(config)
 
 		backup := client.GetBackup(c.Args().Get(0))
 		if backup.Type == api.BACKUP_TYPE_UNMANAGED {
-			log.Fatal("Cannot start unmanaged backup using `run` command, try `start-unmanaged`")
+			return cli.NewExitError("Cannot start an unmanaged backup using `run` command, try `start-unmanaged`.", 1)
 		}
 
-		actions.RunBackup(client, backup)
+		actions.RunBackup(client, backup, logger)
 
 		return nil
 	},

--- a/config/loader.go
+++ b/config/loader.go
@@ -17,7 +17,8 @@ type Config struct {
 		ClientId     string `toml:"client_id"`
 		ClientSecret string `toml:"client_secret"`
 	}
-	LogLevel LogLevel `toml:"log_level"`
+	LogLevel  LogLevel `toml:"log_level"`
+	ApiServer string   `toml:"api_server"`
 }
 
 type LogLevel struct {
@@ -82,6 +83,7 @@ func (l *ConfigLoader) LoadString(tomlText string) (*Config, error) {
 		LogLevel: LogLevel{
 			Level: log.Info,
 		},
+		ApiServer: "https://api.backupshq.com",
 	}
 	metadata, err := toml.Decode(tomlText, &config)
 	if err != nil {

--- a/config/loader.go
+++ b/config/loader.go
@@ -99,6 +99,8 @@ func (l *ConfigLoader) LoadString(tomlText string) (*Config, error) {
 		return nil, errors.New("Unrecognized TOML key(s) given: " + strings.Join(keysAsString, ", "))
 	}
 
+	config.ApiServer = strings.TrimRight(config.ApiServer, "/")
+
 	return &config, nil
 }
 

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -16,8 +16,9 @@ func TestString(t *testing.T) {
 			t.Errorf("expected a Config struct to be created without error, got %q", err.Error())
 			return
 		}
-		if config.Auth.ClientId != "" {
-			t.Errorf("got %q want %q", config.Auth.ClientSecret, "")
+		expected := "https://api.backupshq.com"
+		if config.ApiServer != expected {
+			t.Errorf("got %q want %q", config.ApiServer, expected)
 		}
 	})
 
@@ -180,6 +181,22 @@ client_secret = "secret"
 		}
 		if !strings.Contains(err.Error(), "Unrecognized TOML key(s) given: ") {
 			t.Errorf("error message should mention unrecognized key, got %q", err)
+		}
+	})
+
+	t.Run("custom api server", func(t *testing.T) {
+		loader := NewConfigLoader(map[string]string{})
+		config, err := loader.LoadString(`
+api_server = "https://api.example.com"
+`)
+
+		if err != nil {
+			t.Errorf("expected a Config struct to be created without error, got %q", err.Error())
+			return
+		}
+		expected := "https://api.example.com"
+		if config.ApiServer != expected {
+			t.Errorf("got %q want %q", config.ApiServer, expected)
 		}
 	})
 }

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -199,6 +199,22 @@ api_server = "https://api.example.com"
 			t.Errorf("got %q want %q", config.ApiServer, expected)
 		}
 	})
+
+	t.Run("custom api server has trailing slash trimmed", func(t *testing.T) {
+		loader := NewConfigLoader(map[string]string{})
+		config, err := loader.LoadString(`
+api_server = "https://api.example.com/"
+`)
+
+		if err != nil {
+			t.Errorf("expected a Config struct to be created without error, got %q", err.Error())
+			return
+		}
+		expected := "https://api.example.com"
+		if config.ApiServer != expected {
+			t.Errorf("got %q want %q", config.ApiServer, expected)
+		}
+	})
 }
 
 func TestFile(t *testing.T) {

--- a/log/stdout.go
+++ b/log/stdout.go
@@ -2,13 +2,17 @@ package log
 
 import (
 	"fmt"
+	"strings"
 )
 
 type StdoutWriter struct {
 }
 
 func (w *StdoutWriter) Write(level int, message string) {
-	fmt.Println(withTime(withLevel(level, message)))
+	lines := strings.Split(message, "\n")
+	for _, line := range lines {
+		fmt.Println(withTime(withLevel(level, line)))
+	}
 }
 
 func CreateStdoutLogger(level int) *Logger {

--- a/utils/tokens.go
+++ b/utils/tokens.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+func GetAccessTokenExpiry(token string) (time.Time, error) {
+	var data = struct {
+		Expiry int64 `json:"exp"`
+	}{}
+
+	err := decodeToken(&data, token)
+
+	return time.Unix(data.Expiry, 0), err
+}
+
+func GetAccessTokenPrincipalId(token string) (string, error) {
+	var data = struct {
+		PrincipalId string `json:"sub"`
+	}{}
+
+	err := decodeToken(&data, token)
+
+	return data.PrincipalId, err
+}
+
+func decodeToken(data interface{}, token string) error {
+	pieces := strings.Split(token, ".")
+	if len(pieces) != 3 {
+		return errors.New("Invalid token format")
+	}
+
+	jsonBytes, err := base64.RawURLEncoding.DecodeString(pieces[1])
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(jsonBytes, &data)
+}

--- a/utils/tokens_test.go
+++ b/utils/tokens_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func assertEquals(t *testing.T, expected interface{}, actual interface{}) {
+	if actual != expected {
+		t.Errorf("Expected %q but got %q", expected, actual)
+	}
+}
+
+const samplePrincipalId = "65fc9e38-fc5d-4f0c-bc4d-e1a05493b4a8"
+const sampleToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI1MmVkMGQxOGZhNWUzMzJmNmU2N2ZhZWM3NzQzYzE4ODYwYmMzODQ0Iiwic3ViIjoiNjVmYzllMzgtZmM1ZC00ZjBjLWJjNGQtZTFhMDU0OTNiNGE4IiwiYXVkIjoiNzUxMjNjNzktZjVlYS00Yjg1LThhMGQtNDViNGU0Zjg4ZGJiIiwiaWF0IjoxNTkxMTk0Mzg4LCJuYmYiOjE1OTExOTQzODgsImV4cCI6MTU5MTE5Nzk4OCwic2NvcGUiOiJhZ2VudCIsInNoYXJkIjoxfQ.rnK5RQkOKc1YnKAuyfRTMqLIJwAo7AG2Hy6fZC910D0"
+const sampleExpiry = 1591197988
+
+func TestGetTokenPrincipal(t *testing.T) {
+	t.Run("valid token", func(t *testing.T) {
+		principalId, err := GetAccessTokenPrincipalId(sampleToken)
+		if err != nil {
+			t.Errorf("Got error: %q", err)
+		}
+		assertEquals(t, samplePrincipalId, principalId)
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		principalId, _ := GetAccessTokenPrincipalId("not-a token")
+		assertEquals(t, "", principalId)
+	})
+}
+
+func TestGetTokenExpiry(t *testing.T) {
+	t.Run("valid token", func(t *testing.T) {
+		expiry, err := GetAccessTokenExpiry(sampleToken)
+		if err != nil {
+			t.Errorf("Got error: %q", err)
+		}
+		assertEquals(t, time.Unix(sampleExpiry, 0), expiry)
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		expiry, _ := GetAccessTokenExpiry("not-a token")
+		assertEquals(t, time.Unix(0, 0), expiry)
+	})
+}


### PR DESCRIPTION
See [T125](https://projects.backbeat.tech/projects/1031eb11-10e9-11e8-a781-f23c916e1390/tasks/125).

This removes the hard-coded `localhost:8000` from everything and generally improves the code throughout. Access tokens can be refreshed now, and it shows some nice detail in the logs when it starts up.