### PR TITLE
Agent ping endpoints

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -39,6 +39,7 @@ func (a *Agent) ping() {
 	shouldFetchBackups := a.apiClient.Ping(a.token)
 
 	if shouldFetchBackups {
+		a.logger.Debug("Changes to backups found... Syncing...")
 		a.update()
 		return
 	}
@@ -46,7 +47,6 @@ func (a *Agent) ping() {
 }
 
 func (a *Agent) update() {
-	a.logger.Debug("Changes to backups found... Syncing...")
 	backups := a.apiClient.ListBackups(api.BACKUP_TYPE_SCHEDULED, a.principal.ID)
 	a.logger.Debug(fmt.Sprintf("Scheduled backups pulled from the API: %d", len(backups)))
 
@@ -79,6 +79,8 @@ Starting BackupsHQ agent
 	a.account = a.apiClient.GetAccount(tokenInfo.AccountId)
 	a.logger.Info(fmt.Sprintf(`This agent belongs to account %s "%s"`, a.account.ID, a.account.Name))
 	a.token = a.apiClient.Register()
+
+	a.update()
 
 	a.waitGroup.Add(1)
 	go func() {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"fmt"
 	"time"
+	"sync"
 
 	"github.com/backupshq/agent/actions"
 	"github.com/backupshq/agent/api"
@@ -20,6 +21,7 @@ type Agent struct {
 	token		  api.AgentToken
 	backups       map[string]api.Backup
 	crons         map[string]*cron.Cron
+	waitGroup 	  sync.WaitGroup
 }
 
 func Create(c *config.Config) *Agent {
@@ -78,6 +80,7 @@ Starting BackupsHQ agent
 	a.logger.Info(fmt.Sprintf(`This agent belongs to account %s "%s"`, a.account.ID, a.account.Name))
 	a.token = a.apiClient.Register()
 
+	a.waitGroup.Add(1)
 	go func() {
 		for {
 			a.ping()
@@ -85,5 +88,5 @@ Starting BackupsHQ agent
 		}
 	}()
 
-	time.Sleep(time.Minute * 100)
+	a.waitGroup.Wait()
 }

--- a/api/agent.go
+++ b/api/agent.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+type AgentToken struct {
+	Token string
+}
+
+func (c *ApiClient) Register() AgentToken {
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Fatal("Unable to get hostname. ", err)
+	}
+	var requestBody = []byte(fmt.Sprintf(`{"hostname":"%s"}`, hostname))
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/agents/register", c.server), bytes.NewBuffer(requestBody))
+	if err != nil {
+		log.Fatal("Error reading request. ", err)
+	}
+	c.AddAuthHeader(req)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		log.Fatal("Error reading response. ", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		log.Fatal("Unable to register agent: HTTP " + resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal("Error reading body. ", err)
+	}
+
+	var token AgentToken
+	err = json.Unmarshal(body, &token)
+	return token
+}
+
+func (c *ApiClient) Ping(token AgentToken) bool {
+	req, err := c.get(fmt.Sprintf("/agents/ping/%s", token.Token))
+	if err != nil {
+		log.Fatal("Error creating request. ", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		log.Fatal("Error reading response. ", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 && resp.StatusCode != 304 {
+		log.Fatal("Unable to ping API: HTTP " + resp.Status)
+	}
+
+	return resp.StatusCode == 200
+}

--- a/command/agent.go
+++ b/command/agent.go
@@ -9,16 +9,9 @@ import (
 var Agent = cli.Command{
 	Name:  "agent",
 	Usage: "Run the BackupsHQ agent",
-	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:  "sync",
-			Value: "* * * * *",
-			Usage: "Cron expression representing how frequently the agent will sync with the API.",
-		},
-	},
 	Action: func(c *cli.Context) error {
 		config := config.LoadCli(c)
-		agent := agent.Create(config, c.String("sync"))
+		agent := agent.Create(config)
 		agent.Start()
 
 		return nil


### PR DESCRIPTION
See [T121 Agent ping endpoint](https://projects.backbeat.tech/projects/1031eb11-10e9-11e8-a781-f23c916e1390/tasks/121) and [API pull request](https://github.com/backbeat-tech/backupshq/pull/26)

My Go is definitely a little rusty but all seems to be working well! 

This seemed like a suitable branch to find a slightly more permanent solution to keep the agent running permanently instead of `time.Sleep(time.Minute * 100)`, I did a bit of research and it seems using `sync.WaitGroup` is a pretty standard way of doing it I think so I've implemented that here too.

Like I mentioned in the API PR, naming of the hash/token could be better.